### PR TITLE
Add agent skills and slim Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,192 +1,38 @@
-# Slack-MM2 Sync Development Instructions
+# Slack-MM2 Sync — Copilot Instructions (Lean)
 
-Always follow these instructions first before gathering additional context. Only fallback to search or direct commands when you encounter unexpected information that does not match the information provided here.
+All detailed procedures (commands, step-by-step workflows, invariants, test checklists) live in Agent Skills under `.github/skills/`. If you need to perform a workflow described in project docs, consult the corresponding skill first and follow the doc links inside the skill.
 
-## Project Overview
-Slack-MM2 Sync is a monorepo for one-way data synchronization from Slack to Mattermost. The project includes:
-- **Backend**: Python FastAPI application for API, file processing, and data export
-- **Frontend**: React/Vite web interface for upload management and monitoring 
-- **Mattermost Plugin**: Go-based plugin for importing data into Mattermost
-- **Infrastructure**: Docker Compose configurations and Kubernetes manifests
+## Project overview
 
-## Working Effectively
+Slack-MM2 Sync is a monorepo for one-way synchronization from Slack to Mattermost.
 
-### Initial Setup and Dependencies
-- **Python**: Version 3.14+ required (project tested with Python 3.14)
-- **Node.js**: Version 20+ required (tested with Node.js 20.19.5, npm 10.8.2)
-- **Go**: Version 1.22+ required (tested with Go 1.24.7)
-- **Docker**: Required for full development environment
+Main components:
+- Backend: Python/FastAPI app (import + export orchestration)
+- Frontend: React/Vite UI
+- Mattermost plugin: Go plugin bundle built via Docker
+- Infrastructure: Docker Compose (dev/prod) and supporting manifests
 
-### Backend Development (Python FastAPI)
-- **Virtual Environment**: ALWAYS work within a Python virtual environment. Create it in the project root: `python3 -m venv .venv` and activate: `source .venv/bin/activate`.
-- **Install dependencies**: `cd backend && pip install -r requirements.txt` -- takes ~18 seconds
-- **Code formatting**: `black app alembic tests` -- takes <1 second. ALWAYS run before committing
-- **Unit tests**: `pytest tests/unit` -- takes ~1.5 seconds for 2 tests  
-- **Unit tests with coverage**: `pytest tests/unit --cov=app --cov-report=term-missing` -- takes ~6 seconds
-- **Integration tests**: `pytest tests/integration` -- takes ~1 second (requires external services for full functionality)
-- **All tests with coverage**: `pytest --cov=app --cov-report=term-missing` -- takes ~6 seconds
-- **Database migrations**: `alembic -c alembic.ini upgrade head` (from project root)
-- **NEVER CANCEL**: Migration commands may take several minutes depending on data size
+## How to use skills
 
-#### Backend Structure
-- `app/main.py` - FastAPI application entry point with lifespan management
-- `app/api/` - REST API endpoints (upload, export, plugin, stats, progress, jobs)
-- `app/models/` - SQLAlchemy database models
-- `app/services/` - Business logic for backup processing and export to Mattermost
-- `alembic/` - Database migration scripts
-- `tests/unit/` - Unit tests (mock external dependencies)
-- `tests/integration/` - Integration tests (require running services)
+Before changing behavior or running an operational workflow, open the matching skill in `.github/skills/<skill-name>/SKILL.md` and follow its “Related docs” links.
 
-#### Environment Variables for Backend Testing
-For integration tests that connect to Mattermost API:
-- `MATTERMOST_API_TOKEN=5x7rr788c7gwdnkdr9imb49ffo` (dev environment default)
-- `MATTERMOST_API_URL=http://localhost:8065/api/v4/users/me`
-#### Import Configuration (Single-Pass Importer)
-Current unified single-pass importer (messages + reactions + attachments + emojis) uses fixed constants for predictable behavior:
-* `IMPORT_URL_PREFIXES` — CSV of allowed `url_private` prefixes for attachments (default: `https://files.slack.com`). Test dataset adds `http://test-files:9000`.
-* `ATTACHMENT_URL_TIMEOUT_SECONDS` — extended timeout (seconds) for large attachment streaming via plugin endpoint `/attachment_from_url` (default 600). Increase for large videos; decrease to detect stalls more aggressively.
+Skill index:
+- Backend dev workflow: `.github/skills/backend-fastapi-dev/SKILL.md`
+- Import/export pipeline invariants: `.github/skills/backend-import-export-pipeline/SKILL.md`
+- DB + Alembic operations: `.github/skills/db-alembic-ops/SKILL.md`
+- Docker Compose workflows: `.github/skills/infra-docker-compose/SKILL.md`
+- Plugin build/deploy: `.github/skills/plugin-mm-importer-dev/SKILL.md`
+- Mini backup regression (deterministic E2E): `.github/skills/mini-backup-regression/SKILL.md`
+- Job restart endpoint/workflow: `.github/skills/job-restart-feature/SKILL.md`
+- Documentation rules: `.github/skills/docs-policy/SKILL.md`
+- Frontend UI smoke/E2E (Playwright): `.github/skills/webapp-testing/SKILL.md`
 
-### Frontend Development (React/Vite)
-- **Install dependencies**: `cd frontend && npm ci` -- takes ~7 seconds
-- **Linting**: `npm run lint` -- takes <1 second. ALWAYS run before committing  
-- **Build**: `npm run build` -- takes ~1.7 seconds
-- **Development server**: `npm run dev` (starts on port 5173)
-- **Preview production build**: `npm run preview`
+## Repository-wide policy (not duplicated in skills)
 
-#### Frontend Structure
-- `src/App.jsx` - Main application component with corporate panel layout
-- `src/components/UI.jsx` - Reusable UI components (Header, Sidebar, Card, Button, StatusBadge)
-- `src/components/ui.css` - Dark theme styling with CSS variables
+Environment variables:
+- Do not use env vars as feature flags for core logic.
+- Do use env vars for external configuration (credentials, URLs, connection strings, timeouts).
 
-### Mattermost Plugin Development (Go)
-- **Quick build (multi-stage Docker)**: `bash infra/plugin/build-docker.sh` (≈69s first build with cache warmup). NEVER CANCEL mid-way.
-- **Output**: `infra/plugin/dist/mm-importer-X.Y.Z.tar.gz` ready for upload / publication
-- **Plugin ID**: `mm-importer` (version reflected in `plugin.json`)
-- **Requirements**: Docker (preferred). Direct host Go/Node setup no longer supported (legacy scripts removed).
-- **Mattermost GitHub**: https://github.com/mattermost/mattermost (plugin API examples)
-- **Mattermost API docs**: https://developers.mattermost.com/api-documentation/
-- **Mattermost Plugin docs**: https://developers.mattermost.com/integrate/plugins/components/server/
-- **Server API reference**: https://developers.mattermost.com/integrate/reference/server/server-reference
+## Canonical documentation
 
-#### Plugin Structure  
-- `plugin.json` - Manifest (id/version)
-- `server/` - Go server implementation
-- `webapp/` - React webapp (if any UI)
-- `build-docker.sh` - Multi-stage Docker build helper (authoritative path)
-
-#### Deprecated Artifacts Removed
-Legacy `build-dev.sh` and the old Makefile have been removed in favor of the reproducible Docker multi-stage build. Use only `build-docker.sh`.
-
-### Environment Variable Policy
-- **DO NOT** use environment variables as feature flags to control application logic (e.g., enabling/disabling a code path). All core features should be enabled and work out-of-the-box.
-- **DO** use environment variables for external configuration that changes between environments, such as:
-  - API tokens, secrets, and credentials
-  - Database connection strings (e.g., `DATABASE_URL`)
-  - External service URLs (e.g., `MATTERMOST_API_URL`)
-  - Ports and hostnames
-  - Long-running external operation timeouts (e.g., `ATTACHMENT_URL_TIMEOUT_SECONDS` for large Slack attachment streaming via plugin; default 600s)
-- Debugging or performance-tuning options should not be managed by environment variables in production code. If such functionality is needed, it should be exposed via dedicated debug endpoints or logging configurations.
-
-### Docker Development Environment
-
-#### Creating Required .env.dev File
-Before using Docker Compose, create `infra/.env.dev`:
-```bash
-cd infra
-cat > .env.dev << EOF
-SLACK_VERIFICATION_TOKEN=test_token
-SLACK_BOT_TOKEN=test_bot_token  
-SLACK_SIGNING_SECRET=test_signing_secret
-EOF
-```
-For production compose runs use `infra/.env.prod` with real Mattermost credentials.
-
-#### Development Environment (docker-compose.dev.yml)
-- **Start all services**: `cd infra && docker compose -f docker-compose.dev.yml up --build`
-- **NEVER CANCEL**: Initial build may take 15+ minutes downloading images and building containers
-- **CRITICAL**: Set timeout to 30+ minutes for first build. Subsequent builds are faster with caching
-- **Services included**: backend, frontend, Mattermost, PostgreSQL, plugin builder
-- **Access points**:
-  - Backend API: http://localhost:8000  
-  - Frontend UI: http://localhost:5173
-  - Mattermost: http://localhost:8065
-  - PostgreSQL: localhost:5432 (user/pass/db: slack-mm)
-
-#### Default Credentials (Development)
-- **Mattermost admin user**: `admin` / `P@ssw0rd`
-- **Mattermost admin token**: `5x7rr788c7gwdnkdr9imb49ffo`
-- **Mattermost team**: `test` (ID: b7u9rycm43nip86mdiuqsxdcbe)
-- **Database**: user `slack-mm`, password `slack-mm`, database `slack-mm`
-
-### Database Operations
-- **Migrations**: Run from project root with `alembic -c alembic.ini upgrade head`
-- **Migration path**: `backend/alembic/` (relative to project root)  
-- **Configuration**: `alembic.ini` in project root
-- **Connection**: Uses DATABASE_URL environment variable
-
-### Debugging Tips
-- Use something like `docker compose -f infra/docker-compose.dev.yml exec db psql -U slack-mm -d slack-mm -P pager=off -c "select * from entities limit 100;"` to troubleshoot database entities.
-
-### Legacy features
-- If you encounter legacy code or features, document them and consider refactoring or removing them in future updates.
-- If you make a feture legacy, please document it clearly in the code comments.
-
-### Documentation Policy
-- Follow `docs/documentation-policy.md` whenever you add or update feature-specific Markdown files. Keep component READMEs concise and link out to deeper docs for complex subsystems.
-
-## Validation and Testing
-
-### Manual Validation Scenarios
-After making changes, ALWAYS test these scenarios:
-
-#### Backend API Testing
-1. **Health check**: `curl http://localhost:8000/healthcheck` should return `{"status": "healthy"}`
-2. **File upload**: Test POST to `/upload` with a sample file
-3. **Export status**: Check GET `/export/status` returns current export state
-4. **Plugin management**: Test `/plugin/status`, `/plugin/deploy`, `/plugin/enable` endpoints
-
-#### Frontend UI Testing  
-1. **Load application**: Navigate to http://localhost:5173
-2. **Upload interface**: Verify file upload form is functional
-3. **Plugin management**: Check plugin status display and control buttons
-4. **Export monitoring**: Verify export progress and status updates
-
-#### Integration Testing
-1. **Database connectivity**: Ensure migrations run successfully
-2. **Mattermost integration**: Verify plugin deployment and enablement
-3. **End-to-end workflow**: Upload → Process → Export → Verify in Mattermost
-
-### CI/CD Validation
-When you finished your work, and especially before committing, ALWAYS run:
-- **Backend**: `cd backend && black app alembic tests && pytest --cov=app --cov-report=term-missing`
-- **Frontend**: `cd frontend && npm run lint && npm run build`
-
-## Common Tasks and Timing Expectations
-
-### Build Times (Set appropriate timeouts)
-- Python dependency install: ~18 seconds (timeout: 60s)
-- Frontend dependency install: ~7 seconds (timeout: 30s)  
-- Frontend build: ~1.7 seconds (timeout: 30s)
-- Plugin build: ~69 seconds (timeout: 120s)
-- Docker development environment: 15+ minutes first time (timeout: 30+ minutes)
-
-### CLI commands
-- Set reasonable timeouts when running commands if possible.
-- Always limit expected output by mumber of lines as output may be large. Try to limit to 20 lines or less where possible, but it depends on the command. Try to filter output to only what is necessary where possible.
-
-## File Locations
-
-### Key Configuration Files
-- `backend/requirements.txt` - Python dependencies
-- `frontend/package.json` - Node.js dependencies and scripts
-- `infra/plugin/plugin.json` - Mattermost plugin manifest
-- `alembic.ini` - Database migration configuration (project root)
-- `infra/docker-compose.dev.yml` - Development environment configuration
-
-### Important Directories
-- `backend/app/` - FastAPI application source
-- `backend/tests/` - Python test suites
-- `frontend/src/` - React application source  
-- `infra/plugin/` - Mattermost plugin source
-- `backend/alembic/` - Database migration scripts
-- `infra/` - Infrastructure and deployment configurations
+If you need a single starting point, use [docs/dev.md](../docs/dev.md). For doc-writing rules, use [docs/documentation-policy.md](../docs/documentation-policy.md).

--- a/.github/skills/backend-fastapi-dev/SKILL.md
+++ b/.github/skills/backend-fastapi-dev/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: backend-fastapi-dev
+description: FastAPI backend dev workflow for Slack-MM2 Sync (Python 3.14+, venv, Alembic migrations, black, pytest). Use when changing API endpoints, importer/exporter code, or debugging backend behavior.
+license: Complete terms in LICENSE.txt
+---
+
+# Backend FastAPI Development
+
+Use this skill when working on the Python backend in `backend/` (API, import/export pipeline, DB interactions).
+
+## When to use
+
+- Editing FastAPI routes under `backend/app/api/`
+- Changing business logic under `backend/app/services/`
+- Updating SQLAlchemy models under `backend/app/models/`
+- Running `black` / `pytest`, or diagnosing failing backend tests
+- Debugging `/healthcheck`, job progress, plugin management endpoints
+
+## Local dev (outside Docker)
+
+Prereqs:
+- Python 3.14+
+- A running Postgres (or use docker compose dev stack for DB/Mattermost)
+
+Workflow:
+1. Create/activate venv (repo root):
+   - `python3 -m venv .venv`
+   - `source .venv/bin/activate`
+2. Install deps:
+   - `cd backend && pip install -r requirements.txt`
+3. Apply migrations (repo root):
+   - `alembic -c alembic.ini upgrade head`
+4. Run the backend:
+   - `cd backend && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`
+
+Health check:
+- `curl http://localhost:8000/healthcheck` (also available as `/api/healthcheck`)
+- Expected JSON (per integration test): `{"status": "ok"}`
+
+## Recommended dev workflow (Docker full stack)
+
+This repo’s default dev workflow is running the full compose stack (backend + frontend + db + mattermost + test-files).
+
+- Create `infra/.env.dev` (dummy tokens are fine for local dev)
+- Start stack:
+  - `docker compose -f infra/docker-compose.dev.yml up --build -d`
+
+Common endpoints:
+- Backend: `http://localhost:8000/healthcheck`
+- Frontend: `http://localhost:5173`
+
+## Code quality
+
+ALWAYS run before committing backend changes:
+- Format: `cd backend && black app alembic tests`
+- Tests: `cd backend && pytest --cov=app --cov-report=term-missing`
+
+If you only need a quick signal:
+- `cd backend && pytest tests/unit`
+
+## Debugging checklist
+
+- If backend doesn’t start, migrations may still be running in the lifespan hook (don’t assume Uvicorn is “hung”).
+- Check logs:
+  - `docker compose -f infra/docker-compose.dev.yml logs -f backend`
+- If `/healthcheck` fails, look for:
+  - DB connection errors
+  - Alembic migration errors
+  - Exceptions during FastAPI lifespan startup
+
+## Related docs
+
+- Developer workflow and testing: [docs/dev.md](../../../docs/dev.md)
+- Backend overview + invariants: [backend/README.md](../../../backend/README.md)
+- Healthcheck contract: [backend/tests/integration/test_api_healthcheck.py](../../../backend/tests/integration/test_api_healthcheck.py)

--- a/.github/skills/backend-import-export-pipeline/SKILL.md
+++ b/.github/skills/backend-import-export-pipeline/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: backend-import-export-pipeline
+description: Slack-MM2 Sync import/export pipeline rules: single-pass deterministic importer, monotonic progress counters, merge_job_meta semantics, and exporter dependency order. Use when modifying importer/exporter stages or progress behavior.
+license: Complete terms in LICENSE.txt
+---
+
+# Import/Export Pipeline (Backend)
+
+This skill encodes the project’s core invariants for the unified single-pass pipeline and deterministic progress tracking.
+
+## When to use
+
+- Changing import stages, progress reporting, or `ImportJob.meta`
+- Adding new counters (`*_processed`, `*_exported`) or changing counter semantics
+- Modifying exporter orchestration order or entity dependency logic
+- Debugging progress bars / “early success” behavior used by integration checks
+
+## Canonical pipeline (single pass)
+
+Stages:
+- `extracting → users → channels → messages → ready_export → exporting → done`
+
+Key rule:
+- Reactions/attachments/custom-emoji references are captured during the single pass through messages (no separate reaction/attachment stages).
+
+## Deterministic progress invariants
+
+- All ingestion counters (`*_processed`) are monotonically non-decreasing.
+- When transitioning to `exporting` / `done`, the backend freezes denominators in `meta.totals` and sets `totals_frozen=true`.
+- Frontend export progress should use `*_exported` against `meta.totals.*`.
+
+## Atomic meta updates (`merge_job_meta`)
+
+To avoid lost updates on JSONB `meta`, updates must be atomic (single SQL UPDATE) using the project’s merge builder semantics:
+- `incr`: atomic increment
+- `max`: monotonic maximum (safety)
+- `set`: set exact values (stage, flags)
+- `nested`: merge nested objects (e.g., `totals`, `durations_ms`)
+- `remove`: remove keys (rare)
+
+Rule of thumb:
+- Do NOT implement ORM “read-modify-write” loops for `meta`.
+
+## Export ordering
+
+Global type barrier order:
+- `user → custom_emoji → channel → message → attachment → reaction`
+
+Meaning:
+- A later type must not start exporting until previous type has no remaining `pending` entities across jobs in `exporting`.
+
+## If you add a new counter or entity type
+
+Checklist:
+- Update the importer to increment the new `*_processed` counter only after the entity meets base invariants.
+- Update export logic and/or exported counters if the frontend needs export progress for that type.
+- Update docs where counters are described.
+- Update the mini-backup regression expected values if it changes deterministic totals.
+
+## Related docs
+
+- Pipeline + dev workflow notes: [docs/dev.md](../../../docs/dev.md)
+- Backend overview: [backend/README.md](../../../backend/README.md)
+- Import stages + counters implementation: [backend/app/services/backup/orchestrator.py](../../../backend/app/services/backup/orchestrator.py)
+- Atomic meta updates implementation: [backend/app/services/backup/meta_utils.py](../../../backend/app/services/backup/meta_utils.py)
+- Export module overview: [backend/app/services/export/README.md](../../../backend/app/services/export/README.md)
+- Export ordering implementation: [backend/app/services/export/orchestrator.py](../../../backend/app/services/export/orchestrator.py)

--- a/.github/skills/db-alembic-ops/SKILL.md
+++ b/.github/skills/db-alembic-ops/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: db-alembic-ops
+description: Database + Alembic workflow for Slack-MM2 Sync (migrations, collapsed history, NEVER CANCEL guidance, and troubleshooting queries). Use when changing schema, debugging DB state, or dealing with migration failures.
+license: Complete terms in LICENSE.txt
+compatibility: Requires Postgres access; Docker Compose recommended for dev.
+---
+
+# Database & Alembic Operations
+
+## When to use
+
+- Running or debugging Alembic migrations
+- Inspecting `entities`, `entity_relations`, `import_jobs` state
+- Updating schema or indexes
+- Investigating migration/startup failures
+
+## Migrations
+
+Canonical command (repo root):
+- `alembic -c alembic.ini upgrade head`
+
+Important:
+- Migrations are also applied automatically when backend starts (lifespan hook). If backend appears “stuck”, it may be running migrations.
+- **NEVER CANCEL** a migration command once started.
+
+## Collapsed migration history
+
+This repo uses a collapsed history model. For clean DBs, `upgrade head` is the expected flow.
+If you’re dealing with a historical DB/schema mismatch, follow the guidance in `backend/README.md` / `docs/dev.md` rather than guessing.
+
+## Common troubleshooting
+
+- View backend logs (migration errors surface there):
+  - `docker compose -f infra/docker-compose.dev.yml logs -f backend`
+
+- Inspect DB quickly:
+  - `docker compose -f infra/docker-compose.dev.yml exec db \
+      psql -U slack-mm -d slack-mm -P pager=off -c "select * from import_jobs order by id desc limit 5;"`
+
+- Inspect entities:
+  - `docker compose -f infra/docker-compose.dev.yml exec db \
+      psql -U slack-mm -d slack-mm -P pager=off -c "select id, entity_type, status from entities order by id desc limit 20;"`
+
+## Related docs
+
+- Migrations + DB policy: [docs/dev.md](../../../docs/dev.md)
+- Schema notes: [backend/README.md](../../../backend/README.md)
+- Infra DB notes: [infra/README.md](../../../infra/README.md)
+- DB init/troubleshooting notes: [infra/db/README.md](../../../infra/db/README.md)

--- a/.github/skills/docs-policy/SKILL.md
+++ b/.github/skills/docs-policy/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: docs-policy
+description: Documentation policy for Slack-MM2 Sync. Use when adding/updating Markdown docs so they stay discoverable, focused, and non-duplicative across backend/frontend/infra/plugin.
+license: Complete terms in LICENSE.txt
+---
+
+# Documentation Policy
+
+## When to use
+
+- Adding a new feature doc in `docs/` or component directories
+- Updating behavior that is already documented
+- Reviewing a PR that includes docs changes
+
+## Core rules
+
+- Prefer updating an existing component `README.md` over creating a new doc.
+- Create a dedicated doc only when it captures:
+  - Cross-component behavior
+  - Operational nuance / manual steps
+  - Non-trivial reasoning (algorithms, SQL patterns, race-condition mitigations)
+  - Recovery / rollback guidance
+- Place the doc next to the code it describes (backend docs in `backend/`, plugin docs in `infra/plugin/`, etc.).
+- Keep docs reproducible today; do not include secrets.
+
+## Checklist (author/reviewer)
+
+- README links to the new doc
+- Doc scopes itself clearly (feature/subsystem)
+- Steps are accurate and reproducible
+- Diagrams/scripts match current behavior
+- No credentials or customer data
+
+## Source of truth
+
+- [docs/documentation-policy.md](../../../docs/documentation-policy.md)

--- a/.github/skills/infra-docker-compose/SKILL.md
+++ b/.github/skills/infra-docker-compose/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: infra-docker-compose
+description: Docker Compose workflows for Slack-MM2 Sync (dev full-stack, prod stack, .env.dev/.env.prod, ports, log inspection). Use when starting/stopping services, reproducing bugs, or running integration flows.
+license: Complete terms in LICENSE.txt
+compatibility: Requires Docker and docker compose.
+---
+
+# Infra: Docker Compose Workflows
+
+## When to use
+
+- Spinning up the full development environment (backend+frontend+db+mattermost+test-files)
+- Running end-to-end import/export manually
+- Debugging compose startup, ports, container logs
+- Running production compose locally
+
+## Dev stack (recommended)
+
+1. Ensure `infra/.env.dev` exists (dummy Slack tokens are fine for local dev).
+  - For the canonical file contents, follow the dev docs: [docs/dev.md](../../../docs/dev.md)
+
+2. Start full stack (expect first build to take a long time):
+- `docker compose -f infra/docker-compose.dev.yml up --build -d`
+
+Access points:
+- Backend: `http://localhost:8000/healthcheck`
+- Frontend: `http://localhost:5173`
+- Mattermost: `http://localhost:8065`
+- Test files: `http://localhost:9000`
+
+## Stopping / cleaning
+
+- Clean stop (recommended between runs):
+  - `docker compose -f infra/docker-compose.dev.yml down --remove-orphans -v`
+
+## Logs
+
+- Backend logs:
+  - `docker compose -f infra/docker-compose.dev.yml logs -f backend`
+- Mattermost logs:
+  - `docker compose -f infra/docker-compose.dev.yml logs -f mattermost`
+
+## Prod stack
+
+- Create `infra/.env.prod` with real Mattermost details
+- Start:
+  - `docker compose -f infra/docker-compose.prod.yml up --build -d`
+
+## Notes
+
+- Dev stack uses ephemeral storage (tmpfs): data is lost when containers stop.
+- Frontend container uses “immutable sources + ephemeral deps” (node_modules not written to host).
+
+## Related docs
+
+- Infra overview: [infra/README.md](../../../infra/README.md)
+- Dev workflow and ports: [docs/dev.md](../../../docs/dev.md)

--- a/.github/skills/job-restart-feature/SKILL.md
+++ b/.github/skills/job-restart-feature/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: job-restart-feature
+description: Job restart workflow for Slack-MM2 Sync (POST /api/jobs/{job_id}/restart), including backend behavior, UI conditions, and test expectations. Use when implementing or debugging retry of failed/skipped exports.
+license: Complete terms in LICENSE.txt
+---
+
+# Job Restart Feature
+
+## When to use
+
+- Implementing or debugging “retry failed/skipped entities” flows
+- Adjusting export orchestrator behavior for restarted jobs
+- Updating frontend job card UX around restart
+- Writing/maintaining unit/integration tests for restart
+
+## API contract
+
+Endpoint:
+- `POST /jobs/{job_id}/restart` (also available as `/api/jobs/{job_id}/restart`)
+
+Behavior (high level):
+- Only completed jobs can be restarted
+- Resets `failed`/`skipped` entities back to `pending`
+- Clears their error messages
+- Triggers export orchestrator for that job
+- Successful entities are not reset
+
+## UI behavior
+
+- Restart button appears only when:
+  - job is completed (`success` or `failed`), and
+  - there are retryable entities (`failed` or `skipped`)
+
+## Testing expectations
+
+- Unit tests cover: not found, invalid status, no retryables, success path
+- Integration tests validate end-to-end restart + export trigger
+
+## Source of truth
+
+- Feature doc: [docs/job-restart-feature.md](../../../docs/job-restart-feature.md)
+- Endpoint implementation: [backend/app/api/jobs.py](../../../backend/app/api/jobs.py)
+- Integration coverage: [backend/tests/integration/test_job_restart.py](../../../backend/tests/integration/test_job_restart.py)

--- a/.github/skills/mini-backup-regression/SKILL.md
+++ b/.github/skills/mini-backup-regression/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: mini-backup-regression
+description: Deterministic mini Slack backup regression workflow (docker compose, plugin ensure, upload, early success counters, log scan). Use when changing importer/exporter logic or verifying end-to-end behavior.
+license: Complete terms in LICENSE.txt
+compatibility: Requires Docker and docker compose.
+---
+
+# Mini Backup Regression (E2E)
+
+This skill describes the canonical deterministic end-to-end regression check using the repo’s mini Slack backup dataset.
+
+## When to use
+
+- After changing importer/exporter logic, progress counters, or pipeline stages
+- After changing plugin behavior that affects export
+- When diagnosing “works on my machine” vs CI differences
+
+## Canonical command
+
+From repo root:
+- `./scripts/run_mini_backup_integration.sh`
+
+The script:
+- Brings up compose services
+- Ensures the Mattermost plugin is deployed/enabled
+- Uploads `infra/test-data/slack-mini-backup.zip`
+- Polls `/jobs` and asserts deterministic counters
+- Scans logs for errors
+- Tears down the stack
+
+## Early success semantics
+
+The regression considers the run successful as soon as:
+- stage is `exporting`, and
+- final counters match expected values.
+
+Waiting for `done` is not required for the mini-backup check.
+
+## Expected counters (canonical dataset)
+
+Defaults (may be overridden by env vars in the script):
+- users=4
+- channels=7
+- messages=19
+- attachments=3
+- reactions=4
+
+## Common failures & fixes
+
+- Plugin not enabled → ensure via backend: `POST /plugin/ensure` (also available as `/api/plugin/ensure`)
+- Attachment URLs blocked → ensure `IMPORT_URL_PREFIXES` includes `http://test-files:9000`
+- Backend not healthy → check backend logs; migrations may still be running
+
+## Updating the mini dataset (only when intentional)
+
+If you must change the mini backup content, follow the policy in `docs/dev.md`:
+- Edit unpacked `infra/test-data/slack-mini-backup/`
+- Regenerate zip: `python infra/test-data/build_mini_backup_zip.py`
+- Update expected counters in `scripts/run_mini_backup_integration.sh`
+
+## Related docs
+
+- Canonical regression script: [scripts/run_mini_backup_integration.sh](../../../scripts/run_mini_backup_integration.sh)
+- Mini dataset location: [infra/test-data/slack-mini-backup/](../../../infra/test-data/slack-mini-backup/)
+- Mini-backup policy and rules: [docs/dev.md](../../../docs/dev.md)

--- a/.github/skills/plugin-mm-importer-dev/SKILL.md
+++ b/.github/skills/plugin-mm-importer-dev/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: plugin-mm-importer-dev
+description: Mattermost mm-importer plugin development workflow (SemVer bump, Docker multi-stage build, bundle output, deploy/enable via backend API). Use when changing plugin endpoints, attachment streaming, channel creation, or plugin packaging.
+license: Complete terms in LICENSE.txt
+compatibility: Requires Docker for the canonical build.
+---
+
+# Mattermost Plugin: mm-importer
+
+## When to use
+
+- Editing plugin server code under `infra/plugin/server/`
+- Updating plugin API endpoints or behavior
+- Changing attachment streaming (`/attachment_from_url`) or size validation
+- Building and packaging the plugin bundle for deployment
+
+## Key rules
+
+- **Do not** use legacy build scripts. Use the multi-stage Docker build helper:
+  - `bash infra/plugin/build-docker.sh`
+- If you change plugin code, bump the version in `infra/plugin/plugin.json` following SemVer.
+
+## Build (canonical)
+
+From repo root:
+- `bash infra/plugin/build-docker.sh`
+
+Expected output:
+- `infra/plugin/dist/mm-importer-<version>.tar.gz`
+
+## Deploy / enable via backend
+
+Backend management endpoints are exposed in two equivalent forms:
+- `/plugin/*` (legacy, used by some scripts)
+- `/api/plugin/*` (documented in the root README)
+
+Common endpoints:
+- `GET  /plugin/status` (or `GET /api/plugin/status`)
+- `POST /plugin/ensure` (or `POST /api/plugin/ensure`) — idempotent deploy+enable
+- `POST /plugin/deploy` (or `POST /api/plugin/deploy`)
+- `POST /plugin/enable` (or `POST /api/plugin/enable`)
+- `POST /plugin/reinstall` (or `POST /api/plugin/reinstall`)
+
+Typical flow:
+1. Ensure backend is healthy: `curl http://localhost:8000/healthcheck`
+2. Ensure plugin installed+enabled: `curl -X POST http://localhost:8000/plugin/ensure`
+3. Verify plugin responds (example): `http://localhost:8065/plugins/mm-importer/api/v1/hello`
+
+## Related docs
+
+- Plugin API + build/deploy strategy: [infra/plugin/README.md](../../../infra/plugin/README.md)
+- Backend API routes overview: [backend/app/api/README.md](../../../backend/app/api/README.md)
+- Backend plugin endpoint implementation: [backend/app/api/plugin.py](../../../backend/app/api/plugin.py)
+- Public API examples: [README.md](../../../README.md)

--- a/.github/skills/skill-creator/LICENSE.txt
+++ b/.github/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/skill-creator/SKILL.md
+++ b/.github/skills/skill-creator/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: skill-creator
+description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+license: Complete terms in LICENSE.txt
+---
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match the level of specificity to the task's fragility and variability:
+
+**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+
+**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+
+**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+
+Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+Every SKILL.md consists of:
+
+- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+#### What to Not Include in a Skill
+
+A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+
+- README.md
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- etc.
+
+The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
+
+#### Progressive Disclosure Patterns
+
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+
+**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+
+**Pattern 1: High-level guide with references**
+
+```markdown
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+[code example]
+
+## Advanced features
+
+- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
+- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+**Pattern 2: Domain-specific organization**
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+When a user asks about sales metrics, Claude only reads sales.md.
+
+Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+
+```
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+```
+
+When the user chooses AWS, Claude only reads aws.md.
+
+**Pattern 3: Conditional details**
+
+Show basic content, link to advanced content:
+
+```markdown
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+**Important guidelines:**
+
+- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
+- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+
+## Skill Creation Process
+
+Skill creation involves these steps:
+
+1. Understand the skill with concrete examples
+2. Plan reusable skill contents (scripts, references, assets)
+3. Initialize the skill (run init_skill.py)
+4. Edit the skill (implement resources and write SKILL.md)
+5. Package the skill (run package_skill.py)
+6. Iterate based on real usage
+
+Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Creates example resource directories: `scripts/`, `references/`, and `assets/`
+- Adds example files in each directory that can be customized or deleted
+
+After initialization, customize or remove the generated SKILL.md and example files as needed.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Learn Proven Design Patterns
+
+Consult these helpful guides based on your skill's needs:
+
+- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
+- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+
+These files contain established best practices for effective skill design.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+
+Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+
+#### Update SKILL.md
+
+**Writing Guidelines:** Always use imperative/infinitive form.
+
+##### Frontmatter
+
+Write the YAML frontmatter with `name` and `description`:
+
+- `name`: The skill name
+- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
+  - Include both what the Skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
+  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+
+Do not include any other fields in YAML frontmatter.
+
+##### Body
+
+Write instructions for using the skill and its bundled resources.
+
+### Step 5: Packaging a Skill
+
+Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again

--- a/.github/skills/skill-creator/references/output-patterns.md
+++ b/.github/skills/skill-creator/references/output-patterns.md
@@ -1,0 +1,82 @@
+# Output Patterns
+
+Use these patterns when skills need to produce consistent, high-quality output.
+
+## Template Pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements (like API responses or data formats):**
+
+```markdown
+## Report structure
+
+ALWAYS use this exact template structure:
+
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+
+**For flexible guidance (when adaptation is useful):**
+
+```markdown
+## Report structure
+
+Here is a sensible default format, but use your best judgment:
+
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+
+Adjust sections as needed for the specific analysis type.
+```
+
+## Examples Pattern
+
+For skills where output quality depends on seeing examples, provide input/output pairs:
+
+```markdown
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+```
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+```
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+```
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+```
+
+Follow this style: type(scope): brief description, then detailed explanation.
+```
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.

--- a/.github/skills/skill-creator/references/workflows.md
+++ b/.github/skills/skill-creator/references/workflows.md
@@ -1,0 +1,28 @@
+# Workflow Patterns
+
+## Sequential Workflows
+
+For complex tasks, break operations into clear, sequential steps. It is often helpful to give Claude an overview of the process towards the beginning of SKILL.md:
+
+```markdown
+Filling a PDF form involves these steps:
+
+1. Analyze the form (run analyze_form.py)
+2. Create field mapping (edit fields.json)
+3. Validate mapping (run validate_fields.py)
+4. Fill the form (run fill_form.py)
+5. Verify output (run verify_output.py)
+```
+
+## Conditional Workflows
+
+For tasks with branching logic, guide Claude through decision points:
+
+```markdown
+1. Determine the modification type:
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow: [steps]
+3. Editing workflow: [steps]
+```

--- a/.github/skills/skill-creator/scripts/init_skill.py
+++ b/.github/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path skills/public
+    init_skill.py my-api-helper --path skills/private
+    init_skill.py custom-skill --path /custom/location
+"""
+
+import sys
+from pathlib import Path
+
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# {skill_title}
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
+- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
+- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
+- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" → numbered capability list
+- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources
+
+This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Claude for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Claude's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Claude should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""
+Example helper script for {skill_name}
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for {skill_name}")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()
+'''
+
+EXAMPLE_REFERENCE = """# Reference Documentation for {skill_title}
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices
+"""
+
+EXAMPLE_ASSET = """# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return ' '.join(word.capitalize() for word in skill_name.split('-'))
+
+
+def init_skill(skill_name, path):
+    """
+    Initialize a new skill directory with template SKILL.md.
+
+    Args:
+        skill_name: Name of the skill
+        path: Path where the skill directory should be created
+
+    Returns:
+        Path to created skill directory, or None if error
+    """
+    # Determine skill directory path
+    skill_dir = Path(path).resolve() / skill_name
+
+    # Check if directory already exists
+    if skill_dir.exists():
+        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    # Create skill directory
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"✅ Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"❌ Error creating directory: {e}")
+        return None
+
+    # Create SKILL.md from template
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name,
+        skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / 'SKILL.md'
+    try:
+        skill_md_path.write_text(skill_content)
+        print("✅ Created SKILL.md")
+    except Exception as e:
+        print(f"❌ Error creating SKILL.md: {e}")
+        return None
+
+    # Create resource directories with example files
+    try:
+        # Create scripts/ directory with example script
+        scripts_dir = skill_dir / 'scripts'
+        scripts_dir.mkdir(exist_ok=True)
+        example_script = scripts_dir / 'example.py'
+        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.chmod(0o755)
+        print("✅ Created scripts/example.py")
+
+        # Create references/ directory with example reference doc
+        references_dir = skill_dir / 'references'
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / 'api_reference.md'
+        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("✅ Created references/api_reference.md")
+
+        # Create assets/ directory with example asset placeholder
+        assets_dir = skill_dir / 'assets'
+        assets_dir.mkdir(exist_ok=True)
+        example_asset = assets_dir / 'example_asset.txt'
+        example_asset.write_text(EXAMPLE_ASSET)
+        print("✅ Created assets/example_asset.txt")
+    except Exception as e:
+        print(f"❌ Error creating resource directories: {e}")
+        return None
+
+    # Print next steps
+    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Edit SKILL.md to complete the TODO items and update the description")
+    print("2. Customize or delete the example files in scripts/, references/, and assets/")
+    print("3. Run the validator when ready to check the skill structure")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != '--path':
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 40 characters")
+        print("  - Must match directory name exactly")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path skills/public")
+        print("  init_skill.py my-api-helper --path skills/private")
+        print("  init_skill.py custom-skill --path /custom/location")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"   Location: {path}")
+    print()
+
+    result = init_skill(skill_name, path)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/package_skill.py
+++ b/.github/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+from quick_validate import validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory
+            for file_path in skill_path.rglob('*'):
+                if file_path.is_file():
+                    # Calculate the relative path within the zip
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/skill-creator/scripts/quick_validate.py
+++ b/.github/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.github/skills/webapp-testing/SKILL.md
+++ b/.github/skills/webapp-testing/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Use when verifying frontend behavior (Vite/React UI), reproducing UI bugs, or building minimal E2E/smoke scripts.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing (Playwright)
+
+Use this skill to create small, purpose-built Playwright scripts for verifying the frontend.
+
+## When to use
+
+- Smoke testing the React/Vite UI after changes
+- Reproducing UI regressions (selectors, rendering, API polling)
+- Capturing screenshots and browser console logs
+
+## Recommended approach
+
+1. Ensure the app is running (typically via dev compose):
+   - `docker compose -f infra/docker-compose.dev.yml up -d`
+   - Frontend: `http://localhost:5173`
+2. Use reconnaissance-then-action:
+   - Navigate
+   - Wait for a stable load state
+   - Inspect DOM / take a screenshot
+   - Then implement precise actions/assertions
+
+Note:
+- This repo doesn’t vendor Playwright; install it in your chosen environment per Playwright’s official docs.
+
+## Minimal Playwright script (Python)
+
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    page.goto("http://localhost:5173")
+    page.wait_for_load_state("networkidle")
+
+    page.screenshot(path="/tmp/ui.png", full_page=True)
+
+    # Example: print console logs (optional)
+    # page.on("console", lambda msg: print(msg.type, msg.text))
+
+    browser.close()
+```
+
+## Common pitfalls
+
+- Don’t inspect the DOM before `networkidle` on dynamic apps.
+- Prefer stable selectors (`role=`, `text=`, test IDs) over brittle CSS chains.
+
+## Related docs
+
+- Frontend overview: [frontend/README.md](../../../frontend/README.md)
+- Dev environment and ports: [docs/dev.md](../../../docs/dev.md)


### PR DESCRIPTION
Adds a set of VS Code Agent Skills under .github/skills and simplifies .github/copilot-instructions.md to avoid duplicating workflows already documented in skills.\n\nNotes:\n- Skills are aligned with repo docs/tests and include links to the source-of-truth docs/scripts.\n- Keeps Copilot instructions intentionally lean per docs-policy.